### PR TITLE
Replace S3 summary.trial.estimates with Trial R6 class method

### DIFF
--- a/R/Trial.R
+++ b/R/Trial.R
@@ -7,7 +7,7 @@
 #' @param n (integer) Number of observations (sample size)
 #' @param estimators (list or function) List of estimators or a single unnamed
 #' estimator
-#' @param summary.args (list) Arguments passed on to [summary.trial.estimates]
+#' @param summary.args (list) Arguments passed to summary method
 #' for decision-making
 #' @author Klaus Kähler Holst, Benedikt Sommer
 #' @examples
@@ -45,8 +45,9 @@ Trial <- R6::R6Class("Trial", #nolint
     #' are modified.
     estimates = NULL,
     #' @field summary.args list of arguments that override default values in
-    #' [summary.trial.estimates] when power and sample sizes are estimated with
-    #' [Trial$estimate_power()][Trial] and [Trial$estimate_samplesize()][Trial]
+    #' [Trial$summary()][Trial] when power and sample sizes are
+    #' estimated with [Trial$estimate_power()][Trial] and
+    #' [Trial$estimate_samplesize()][Trial]
     summary.args = list(),
 
     #' @description Initialize new Trial object
@@ -62,8 +63,9 @@ Trial <- R6::R6Class("Trial", #nolint
     #' @param estimators optional list of estimators or single estimator
     #' function
     #' @param summary.args list of arguments that override default values in
-    #' [summary.trial.estimates] when power and sample sizes are estimated with
-    #' [Trial$estimate_power()][Trial] and [Trial$estimate_samplesize()][Trial]
+    #' [Trial$summary()][Trial] when power and sample sizes are
+    #' estimated with [Trial$estimate_power()][Trial] and
+    #' [Trial$estimate_samplesize()][Trial]
     #' @param info optional string describing the model
     initialize = function(outcome,
                           covariates = NULL,
@@ -325,14 +327,14 @@ Trial <- R6::R6Class("Trial", #nolint
     #'
     #' # the basic usage is to apply the summary method to the generated
     #' # trial.estimates object.
-    #' summary(trial$estimates)
+    #' trial$summary()
     #'
     #' # combining Trial$run and summary is faster than using
     #' # Trial$estimate_power when modifying only the parameters of the
     #' # decision-making function
     #' sapply(
     #'   c(0, 0.25, 0.5),
-    #'   \(ni) summary(trial$estimates, ni.margin = ni)[, "power"]
+    #'   \(ni) trial$summary(ni.margin = ni)[, "power"]
     #' )
     #'
     #' # changing the ate parameter value
@@ -349,9 +351,9 @@ Trial <- R6::R6Class("Trial", #nolint
     #' @description Estimates statistical power for a specified trial
     #'
     #' Convenience method that first runs [Trial$run()][Trial] and subsequently
-    #' applies [summary.trial.estimates] to derive the power for each estimator.
-    #' The behavior of passing arguments to lower level functions is identical
-    #' to [Trial$run()][Trial].
+    #' applies [Trial$summary()][Trial] to derive the power for each
+    #' estimator. The behavior of passing arguments to lower level functions is
+    #' identical to [Trial$run()][Trial].
     #' @examples
     #' # toy examples with small number of Monte-Carlo replicates
     #' # future::plan("multicore")
@@ -386,7 +388,7 @@ Trial <- R6::R6Class("Trial", #nolint
 
       args <- c(list(...), list(n = n, R = R, estimators = estimators))
       r <- do.call(self$run, args)
-      sr <- do.call(summary, c(list(r), sum.args))
+      sr <- do.call(self$summary, c(list(estimates = r), sum.args))
       return(sr[, "power"])
     },
 
@@ -494,6 +496,94 @@ Trial <- R6::R6Class("Trial", #nolint
         return(res)
 
       },
+
+    #' @description Summarize Monte Carlo studies of different estimators for
+    #'   the treatment effect in a randomized clinical trial. The method reports
+    #'   the power of both superiority tests (one-sided or two-sided) and
+    #'   non-inferiority tests, together with summary statistics of the
+    #'   different estimators.
+    #' @param level significance level
+    #' @param null null hypothesis to test
+    #' @param ni.margin non-inferiority margin
+    #' @param alternative alternative hypothesis (not equal !=, less <,
+    #'   greater >)
+    #' @param reject.function Optional function calculating whether to reject
+    #'   the null hypothesis
+    #' @param true.value Optional true parameter value
+    #' @param nominal.coverage Width of confidence limits
+    #' @param estimates Optional trial.estimates object. When provided, these
+    #'   estimates will be used instead of the object's stored estimates. This
+    #'   allows calculating summaries for different trial results without
+    #'   modifying the object's state.
+    #' @param ... additional arguments to lower level functions
+    #' @return matrix with results of each estimator stored in separate rows
+    summary = function(level = .05,
+                          null = 0,
+                          ni.margin = NULL,
+                          alternative = c("!=", "<", ">"),
+                          reject.function = NULL,
+                          true.value = NULL,
+                          nominal.coverage = 0.9,
+                          estimates = NULL,
+                          ...) {
+      est <- if (!is.null(estimates)) estimates else self$estimates
+      if (is.null(est)) {
+        stop("No estimates available. Run trial first.")
+      }
+      alternative <- gsub(" ", "", tolower(alternative[1]))
+      q_alpha_cov <- qnorm(1 - (1 - nominal.coverage) / 2) # quantile for
+      # calculating the nominal coverage when true.value is supplied
+      q_alpha_rej <- qnorm(1 - level / 2) # quantile used for decision making
+      # about the null hypothesis (here two-sided test, below for one-sided
+      # test)
+      if (alternative %in% c("less", "<")) {
+        alternative <- "<"
+        q_alpha_rej <- qnorm(1 - level)
+      }
+      if (alternative %in% c("greater", ">")) {
+        alternative <- ">"
+        q_alpha_rej <- qnorm(1 - level)
+      }
+      if (!is.null(ni.margin)) {
+        q_alpha_rej <- qnorm(1 - level)
+        alternative <- ifelse(ni.margin >= 0, "<", ">")
+      }
+
+      if (missing(reject.function)) {
+        reject.function <- function(lower, upper, ...) {
+          if (alternative == "<") {
+            if (!is.null(ni.margin)) {
+              return(upper < ni.margin)
+            }
+            return(upper < null)
+          }
+          if (alternative == ">") {
+            if (!is.null(ni.margin)) {
+              return(lower > ni.margin)
+            }
+            return(lower > null)
+          }
+          return((upper < null) | (lower > null))
+        }
+      } else {
+        reject.function <- add_dots(reject.function)
+      }
+      res <- lapply(est$estimates, function(est) {
+        return(private$runtrials_summarize(
+          estimates = est,
+          q_alpha_rej = q_alpha_rej,
+          q_alpha_cov = q_alpha_cov,
+          null = null,
+          true_value = true.value,
+          reject_function = reject.function
+        ))
+      })
+      # res <- lapply(self$estimates$estimates, function(est) {
+      #   return(runtrials_summarize(estimates = est))
+      # })
+      res <- do.call(rbind, res)
+      return(res)
+    },
 
     #' @description Print method for Trial objects
     #' @param verbose (logical) By default, only print the
@@ -608,6 +698,51 @@ Trial <- R6::R6Class("Trial", #nolint
       private[[attr.name]][names(all_args)] <- all_args
       .flush()
       return(invisible())
+    },
+    runtrials_recalc = function(estimates, q_alpha_rej, q_alpha_cov, null,
+                              reject_function) {
+      est <- estimates[, c("Estimate", "Std.Err")] |>
+        as.data.frame()
+      point_est <- est[, "Estimate"]
+      est[, "z.score"] <- (point_est - null) / est[, "Std.Err"]
+      est[, "lower.CI"] <- point_est - q_alpha_rej * est[, "Std.Err"]
+      est[, "upper.CI"] <- point_est + q_alpha_rej * est[, "Std.Err"]
+      est[, "lower.CI.cov"] <- point_est - q_alpha_cov * est[, "Std.Err"]
+      est[, "upper.CI.cov"] <- point_est + q_alpha_cov * est[, "Std.Err"]
+      est[, "Reject"] <- reject_function(
+        estimate = est[, "Estimate"],
+        stderr = est[, "Std.Err"],
+        lower = est[, "lower.CI"],
+        upper = est[, "upper.CI"]
+      )
+      return(est)
+    },
+
+    runtrials_summarize = function(estimates, q_alpha_rej, q_alpha_cov, null,
+                                   true_value, reject_function) {
+      estimates <- private$runtrials_recalc(
+        estimates = estimates,
+        q_alpha_rej = q_alpha_rej,
+        q_alpha_cov = q_alpha_cov,
+        null = null,
+        reject_function = reject_function
+      )
+      out <- with(estimates, c(
+        estimate = mean(Estimate, na.rm=TRUE),
+        std.err = mean(Std.Err, na.rm=TRUE),
+        std.dev = sd(Estimate, na.rm=TRUE),
+        power = mean(Reject, na.rm=TRUE),
+        na = sum(is.na(Estimate))
+      ))
+      if (!is.null(true_value)) {
+        est_err <- estimates[, "Estimate"] - true_value
+        out[["bias"]] <- mean(est_err, na.rm = TRUE)
+        out[["rmse"]] <- mean(est_err ** 2, na.rm = TRUE) ** 0.5
+        out[["coverage"]] <- mean(
+          (estimates[, "lower.CI.cov"] <= true_value) &
+            (true_value <= estimates[, "upper.CI.cov"]), na.rm = TRUE)
+      }
+      return(out)
     }
   )
 )

--- a/inst/tinytest/test_trial_run.R
+++ b/inst/tinytest/test_trial_run.R
@@ -98,63 +98,70 @@ test_summary.runtrials <- function() {
     ))
   }, estimators = list(mymodel = est_glm()))
   res <- m$run(n = 100, R = 500, p = c(0.5, 0.25))
-
-  # test that summary method calculates descriptive statistic and power
-  # correctly for the estimates of a given estimator
-  s <- summary(res)
-  expect_equal(mean(res$estimates[[1]][, "Estimate"]), s[1, "estimate"])
-  expect_equal(mean(res$estimates[[1]][, "Std.Err"]), s[1, "std.err"])
-  expect_equal(sd(res$estimates[[1]][, "Estimate"]), s[1, "std.dev"])
-  expect_equal(mean(res$estimates[[1]][, "P-value"] < 0.05), s[1, "power"])
-
-  p1 <- power.prop.test(n = 50, p1 = 0.5, p2 = 0.25) # n = obs. per group
-  expect_equal(p1$power, s[1, "power"], tolerance = 0.2)
-
-  s2 <- summary(res, true.value = -.25, alternative = "<", level = 0.05)
-  p2 <- power.prop.test(n = 50, p1 = 0.5, p2 = 0.25, alternative = "one.sided")
-  expect_equal(p2$power, s2[1, "power"], tolerance = 0.1)
-  expect_true(s[1, "power"] < s2[1, "power"])
-
-  # test that nominal coverage around true.value is correctly calculated
-  s3 <- summary(res, true.value = -.25, nominal.coverage = 0.9)
-  expect_equal(s3[, "coverage"], 0.9, tolerance = 0.05)
-  s3 <- summary(res, true.value = -.25, nominal.coverage = 0.5)
-  expect_equal(s3[, "coverage"], 0.5, tolerance = 0.05)
-
-
-  # test ni.margin; expect power around 5% since true value is -0.25
-  s <- summary(res, ni.margin = -.25, alternative = ">")
-  expect_equal(s[1, "power"], 0.05, tolerance = 0.1)
-  # power should go up to 10% when changing significance level to .1
-  # implicitly verify that alternative hypothesis is derived correctly from
-  # the margin
-  s <- summary(res, ni.margin = -.25, level = 0.1)
-  expect_equal(s[1, "power"], 0.1, tolerance = 0.1)
-
-  # test null value argument. power should equal significance level since
-  # true value equals null hypothesis
-  s <- summary(res, null = -.25, alternative = ">", level = 0.05)
-  expect_equal(s[1, "power"], 0.05, tolerance = 0.1)
-  # test that alternative argument also works with "less" and "greater" values
-  s <- summary(res, null = -.25, alternative = "greater", level = 0.05)
-  s1 <- summary(res, null = -.25, alternative = ">", level = 0.05)
-  expect_equal(s[1, "power"], s1[1, "power"])
-
-  s <- summary(res, null = -.25, alternative = "less", level = 0.05)
-  s1 <- summary(res, null = -.25, alternative = "<", level = 0.05)
-  expect_equal(s[1, "power"], s1[1, "power"])
-
-  # test that error occurs when estimates do not contain Estimate and Std.Err
-  # columns
-  res1 <- res
-  res1$estimates[[1]] <- res1$estimates[[1]][, c("Estimate")]
-  expect_error(summary(res1))
-
-  # test that summary works as expected for estimates from more than one
-  # estimator
-  res1 <- m$run(n = 100, R = 10, p = c(0.5, 0.25),
-    estimators = list(est1 = est_glm(), est2 = est_glm()))
-  s <- summary(res1)
-  expect_equal(rownames(s), c("est1", "est2"))
+  
+  # test that deprecation warning is shown
+  expect_warning(s <- summary(res), "deprecated")
+  
+  ## we should remove these tests after deprecation of this method
+  suppressWarnings({
+    # test that summary method calculates descriptive statistic and power
+    # correctly for the estimates of a given estimator
+    s <- summary(res)
+    expect_equal(mean(res$estimates[[1]][, "Estimate"]), s[1, "estimate"])
+    expect_equal(mean(res$estimates[[1]][, "Std.Err"]), s[1, "std.err"])
+    expect_equal(sd(res$estimates[[1]][, "Estimate"]), s[1, "std.dev"])
+    expect_equal(mean(res$estimates[[1]][, "P-value"] < 0.05), s[1, "power"])
+    
+    p1 <- power.prop.test(n = 50, p1 = 0.5, p2 = 0.25) # n = obs. per group
+    expect_equal(p1$power, s[1, "power"], tolerance = 0.2)
+    
+    s2 <- summary(res, true.value = -.25, alternative = "<", level = 0.05)
+    p2 <- power.prop.test(n = 50, p1 = 0.5, p2 = 0.25, alternative = "one.sided")
+    expect_equal(p2$power, s2[1, "power"], tolerance = 0.1)
+    expect_true(s[1, "power"] < s2[1, "power"])
+    
+    # test that nominal coverage around true.value is correctly calculated
+    s3 <- summary(res, true.value = -.25, nominal.coverage = 0.9)
+    expect_equal(s3[, "coverage"], 0.9, tolerance = 0.05)
+    s3 <- summary(res, true.value = -.25, nominal.coverage = 0.5)
+    expect_equal(s3[, "coverage"], 0.5, tolerance = 0.05)
+    
+    # test ni.margin; expect power around 5% since true value is -0.25
+    s <- summary(res, ni.margin = -.25, alternative = ">")
+    expect_equal(s[1, "power"], 0.05, tolerance = 0.1)
+    
+    # power should go up to 10% when changing significance level to .1
+    # implicitly verify that alternative hypothesis is derived correctly from
+    # the margin
+    s <- summary(res, ni.margin = -.25, level = 0.1)
+    expect_equal(s[1, "power"], 0.1, tolerance = 0.1)
+    
+    # test null value argument. power should equal significance level since
+    # true value equals null hypothesis
+    s <- summary(res, null = -.25, alternative = ">", level = 0.05)
+    expect_equal(s[1, "power"], 0.05, tolerance = 0.1)
+    
+    # test that alternative argument also works with "less" and "greater" values
+    s <- summary(res, null = -.25, alternative = "greater", level = 0.05)
+    s1 <- summary(res, null = -.25, alternative = ">", level = 0.05)
+    expect_equal(s[1, "power"], s1[1, "power"])
+    
+    s <- summary(res, null = -.25, alternative = "less", level = 0.05)
+    s1 <- summary(res, null = -.25, alternative = "<", level = 0.05)
+    expect_equal(s[1, "power"], s1[1, "power"])
+    
+    # test that error occurs when estimates do not contain Estimate and Std.Err
+    # columns
+    res1 <- res
+    res1$estimates[[1]] <- res1$estimates[[1]][, c("Estimate")]
+    expect_error(summary(res1))
+    
+    # test that summary works as expected for estimates from more than one
+    # estimator
+    res1 <- m$run(n = 100, R = 10, p = c(0.5, 0.25),
+      estimators = list(est1 = est_glm(), est2 = est_glm()))
+    s <- summary(res1)
+    expect_equal(rownames(s), c("est1", "est2"))
+  })
 }
 test_summary.runtrials()

--- a/man/Trial.Rd
+++ b/man/Trial.Rd
@@ -175,14 +175,14 @@ print(trial$estimates) # trial$estimates == res
 
 # the basic usage is to apply the summary method to the generated
 # trial.estimates object.
-summary(trial$estimates)
+trial$summary()
 
 # combining Trial$run and summary is faster than using
 # Trial$estimate_power when modifying only the parameters of the
 # decision-making function
 sapply(
   c(0, 0.25, 0.5),
-  \(ni) summary(trial$estimates, ni.margin = ni)[, "power"]
+  \(ni) trial$summary(ni.margin = ni)[, "power"]
 )
 
 # changing the ate parameter value
@@ -288,8 +288,9 @@ flushed, i.e. set to its default value \emph{NULL}, when model arguments
 are modified.}
 
 \item{\code{summary.args}}{list of arguments that override default values in
-\link{summary.trial.estimates} when power and sample sizes are estimated with
-\link[=Trial]{Trial$estimate_power()} and \link[=Trial]{Trial$estimate_samplesize()}}
+\link[=Trial]{Trial$summary()} when power and sample sizes are
+estimated with \link[=Trial]{Trial$estimate_power()} and
+\link[=Trial]{Trial$estimate_samplesize()}}
 }
 \if{html}{\out{</div>}}
 }
@@ -304,6 +305,7 @@ are modified.}
 \item \href{#method-Trial-run}{\code{Trial$run()}}
 \item \href{#method-Trial-estimate_power}{\code{Trial$estimate_power()}}
 \item \href{#method-Trial-estimate_samplesize}{\code{Trial$estimate_samplesize()}}
+\item \href{#method-Trial-summary}{\code{Trial$summary()}}
 \item \href{#method-Trial-print}{\code{Trial$print()}}
 \item \href{#method-Trial-clone}{\code{Trial$clone()}}
 }
@@ -343,8 +345,9 @@ the function must return the subjects who are included in the trial)}
 function}
 
 \item{\code{summary.args}}{list of arguments that override default values in
-\link{summary.trial.estimates} when power and sample sizes are estimated with
-\link[=Trial]{Trial$estimate_power()} and \link[=Trial]{Trial$estimate_samplesize()}}
+\link[=Trial]{Trial$summary()} when power and sample sizes are
+estimated with \link[=Trial]{Trial$estimate_power()} and
+\link[=Trial]{Trial$estimate_samplesize()}}
 
 \item{\code{info}}{optional string describing the model}
 }
@@ -684,14 +687,14 @@ print(trial$estimates) # trial$estimates == res
 
 # the basic usage is to apply the summary method to the generated
 # trial.estimates object.
-summary(trial$estimates)
+trial$summary()
 
 # combining Trial$run and summary is faster than using
 # Trial$estimate_power when modifying only the parameters of the
 # decision-making function
 sapply(
   c(0, 0.25, 0.5),
-  \(ni) summary(trial$estimates, ni.margin = ni)[, "power"]
+  \(ni) trial$summary(ni.margin = ni)[, "power"]
 )
 
 # changing the ate parameter value
@@ -712,9 +715,9 @@ trial$run(n = 100, R = 50, estimators = est_glm(robust = FALSE))
 Estimates statistical power for a specified trial
 
 Convenience method that first runs \link[=Trial]{Trial$run()} and subsequently
-applies \link{summary.trial.estimates} to derive the power for each estimator.
-The behavior of passing arguments to lower level functions is identical
-to \link[=Trial]{Trial$run()}.
+applies \link[=Trial]{Trial$summary()} to derive the power for each
+estimator. The behavior of passing arguments to lower level functions is
+identical to \link[=Trial]{Trial$run()}.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Trial$estimate_power(n, R = 100, estimators = NULL, summary.args = list(), ...)}\if{html}{\out{</div>}}
 }
@@ -729,7 +732,7 @@ to \link[=Trial]{Trial$run()}.
 \item{\code{estimators}}{(list or function) List of estimators or a single unnamed
 estimator}
 
-\item{\code{summary.args}}{(list) Arguments passed on to \link{summary.trial.estimates}
+\item{\code{summary.args}}{(list) Arguments passed to summary method
 for decision-making}
 
 \item{\code{...}}{Arguments to covariate, outcome and exclusion model
@@ -840,7 +843,7 @@ refinement points will be used to estimate the power.}
 
 \item{\code{minimum}}{(integer) Minimum sample size.}
 
-\item{\code{summary.args}}{(list) Arguments passed on to \link{summary.trial.estimates}
+\item{\code{summary.args}}{(list) Arguments passed to summary method
 for decision-making}
 }
 \if{html}{\out{</div>}}
@@ -876,6 +879,61 @@ trial$estimate_samplesize(summary.args = list(level = 0.025))
 
 }
 
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Trial-summary"></a>}}
+\if{latex}{\out{\hypertarget{method-Trial-summary}{}}}
+\subsection{Method \code{summary()}}{
+Summarize Monte Carlo studies of different estimators for
+the treatment effect in a randomized clinical trial. The method reports
+the power of both superiority tests (one-sided or two-sided) and
+non-inferiority tests, together with summary statistics of the
+different estimators.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Trial$summary(
+  level = 0.05,
+  null = 0,
+  ni.margin = NULL,
+  alternative = c("!=", "<", ">"),
+  reject.function = NULL,
+  true.value = NULL,
+  nominal.coverage = 0.9,
+  estimates = NULL,
+  ...
+)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{level}}{significance level}
+
+\item{\code{null}}{null hypothesis to test}
+
+\item{\code{ni.margin}}{non-inferiority margin}
+
+\item{\code{alternative}}{alternative hypothesis (not equal !=, less <,
+greater >)}
+
+\item{\code{reject.function}}{Optional function calculating whether to reject
+the null hypothesis}
+
+\item{\code{true.value}}{Optional true parameter value}
+
+\item{\code{nominal.coverage}}{Width of confidence limits}
+
+\item{\code{estimates}}{Optional trial.estimates object. When provided, these
+estimates will be used instead of the object's stored estimates. This
+allows calculating summaries for different trial results without
+modifying the object's state.}
+
+\item{\code{...}}{additional arguments to lower level functions}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+matrix with results of each estimator stored in separate rows
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Trial-print"></a>}}

--- a/man/summary.trial.estimates.Rd
+++ b/man/summary.trial.estimates.Rd
@@ -46,9 +46,7 @@ coverage for the central 90\% confidence interval.}
 matrix with results of each estimator stored in separate rows
 }
 \description{
-Summary method for the Monte Carlo studies of different
-estimators for the treatment effect in a randomized clinical trial
-(trial.estimates objects). The power of both a superiority test (one-sided
-or two-sided) and a non-inferiority test are reported, together with the
-summary statistics of the different estimators.
+\link{Deprecated} Summary method for the Monte Carlo studies of
+different estimators for the treatment effect in a randomized clinical
+trial. Please use Trial$summary() instead.
 }


### PR DESCRIPTION
Convert summary.trial.estimates S3 method to Trial R6 class method:

- Add summary as new R6 method in Trial class
- Add deprecation warning to S3 method
- Modify test functions to handle both s3 and R6 methods

Closes #2 