### PR TITLE
fix(outcome_phreg): time,status variables must be in the data.frame a…

### DIFF
--- a/R/Trial.R
+++ b/R/Trial.R
@@ -819,7 +819,7 @@ trial_simulate <- function(self, n, .niter, ...) {
       }
       xt <- lapply(xt, data.table)
       if (count == 0) nsim <- n * length(xt)
-      for (i in seq_len(length(xt))) {
+      for (i in seq_along(xt)) {
         ## Append subject id and period variable
         xt[[i]][, `:=`(id = ids, num = i - 1)]
       }

--- a/R/outcome_models.R
+++ b/R/outcome_models.R
@@ -367,12 +367,15 @@ outcome_phreg <- function(data,
   timemod <- proc_phreg(model)
   model <- timemod$model
   if (is.null(cens.model)) {
-    if (is.null(model)) stop(
+    if (is.null(model)) {
+      stop(
         "Need 'phreg' object (argument 'model') or specify parametric model"
-    )
-    fcens <- with(model, Surv(time, !status) ~ 1)
-    cens.model <- mets::phreg(fcens, data = model.frame(model))
-    cens.lp <- ~fcens
+      )
+    }
+    fcens <- Surv(time, !status) ~ 1
+    newd <- with(model, data.frame(time, status))
+    cens.model <- mets::phreg(fcens, data = newd)
+    cens.lp <- fcens
   }
   censmod <- proc_phreg(cens.model)
   cens.model <- censmod$model


### PR DESCRIPTION
time,status variables must be in the data.frame when calling phreg and not just in the environment (formula)

Required change with next release of mets


